### PR TITLE
Add Vulkan backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,17 @@
+# Copyright 2020-2021 The Autoware Foundation, Arm Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 project(tvm_vendor)
 
 find_package(ros_environment REQUIRED)
@@ -32,12 +46,17 @@ endif()
 
 include(ExternalProject)
 
+set(PATCH_FILE ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.patch)
+if(ROS_VERSION EQUAL 2)
+  set(PATCH_FILE ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.gpu.patch)
+endif()
+
 ExternalProject_Add(tvm-build
   GIT_REPOSITORY https://github.com/apache/incubator-tvm
   GIT_TAG v0.7.0
   GIT_SHALLOW TRUE
   BUILD_IN_SOURCE TRUE
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.patch
+  PATCH_COMMAND git apply ${PATCH_FILE}
   COMMAND cp <SOURCE_DIR>/cmake/config.cmake <SOURCE_DIR>
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -DCMAKE_POSITION_INDEPENDENT_CODE=ON
   INSTALL_COMMAND ""

--- a/config.cmake.gpu.patch
+++ b/config.cmake.gpu.patch
@@ -1,7 +1,16 @@
 diff --git a/cmake/config.cmake b/cmake/config.cmake
-index 9754385fa..530c4bee1 100644
+index 9754385fa..a093f61fe 100644
 --- a/cmake/config.cmake
 +++ b/cmake/config.cmake
+@@ -79,7 +79,7 @@ set(USE_METAL OFF)
+ # - ON: enable Vulkan with cmake's auto search
+ # - OFF: disable vulkan
+ # - /path/to/vulkan-sdk: use specific path to vulkan-sdk
+-set(USE_VULKAN OFF)
++set(USE_VULKAN ON)
+ 
+ # Whether enable OpenGL runtime
+ set(USE_OPENGL OFF)
 @@ -130,7 +130,7 @@ set(USE_LLVM OFF)
  set(USE_BYODT_POSIT OFF)
  
@@ -11,4 +20,3 @@ index 9754385fa..530c4bee1 100644
  
  # Whether to use MKL
  # Possible values:
-

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,9 @@
   <depend>git</depend>
   <depend>libopenblas-dev</depend>
   <depend>libxml2</depend>
+  <depend condition="$ROS_VERSION == 2">libvulkan-dev</depend>
+  <depend condition="$ROS_VERSION == 2">spirv-headers</depend>
+  <depend condition="$ROS_VERSION == 2">spirv-tools</depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>


### PR DESCRIPTION
Enable Vulkan backend for the ROS2 version of the package.

Part of the backend support for https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/issues/721

Depends on https://github.com/ros/rosdistro/pull/29491 for the rosdep spirv dependencies. The CI will probably need to be re-triggered after it is merged.