### PR TITLE
Fix dlpack and tvm-runtime header inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,5 +144,11 @@ elseif(${ROS_VERSION} EQUAL 2)
     DESTINATION lib
   )
 
+  install(
+    FILES
+      cmake/tvm_runtimeConfig.cmake
+      cmake/tvmConfig.cmake
+    DESTINATION share/${PROJECT_NAME}/cmake)
+
   ament_package()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ elseif(${ROS_VERSION} EQUAL 2)
   ament_export_libraries(tvm tvm_runtime)
 
   install(DIRECTORY ${SOURCE_DIR}/include/tvm/runtime/
-    DESTINATION include/${PROJECT_NAME}/tvm/runtime
+    DESTINATION include/tvm/runtime
   )
 
   install(
@@ -133,7 +133,7 @@ elseif(${ROS_VERSION} EQUAL 2)
     FILES
       ${SOURCE_DIR}/3rdparty/dlpack/include/dlpack/dlpack.h
       ${SOURCE_DIR}/3rdparty/dlpack/contrib/dlpack/dlpackcpp.h
-    DESTINATION include/${PROJECT_NAME}/dlpack
+    DESTINATION include/dlpack
   )
 
   install(DIRECTORY ${SOURCE_DIR}/3rdparty/dmlc-core/include/dmlc

--- a/cmake/tvmConfig.cmake
+++ b/cmake/tvmConfig.cmake
@@ -1,0 +1,4 @@
+add_library(tvm STATIC IMPORTED)
+find_library(tvm_LIBRARY_PATH tvm HINTS "${CMAKE_CURRENT_LIST_DIR}/../../")
+set_target_properties(tvm PROPERTIES IMPORTED_LOCATION "${tvm_LIBRARY_PATH}")
+list(APPEND tvm_LIBRARIES "${tvm_LIBRARY_PATH}")

--- a/cmake/tvm_runtimeConfig.cmake
+++ b/cmake/tvm_runtimeConfig.cmake
@@ -1,0 +1,4 @@
+add_library(tvm_runtime STATIC IMPORTED)
+find_library(tvm_runtime_LIBRARY_PATH tvm_runtime HINTS "${CMAKE_CURRENT_LIST_DIR}/../../")
+set_target_properties(tvm_runtime PROPERTIES IMPORTED_LOCATION "${tvm_runtime_LIBRARY_PATH}")
+list(APPEND tvm_runtime_LIBRARIES "${tvm_runtime_LIBRARY_PATH}")


### PR DESCRIPTION
Partial fix for issue #2. Previously, including these headers required
e.g.:

\#include <tvm_vendor/tvm_vendor/dlpack/dlpack.h>

But now we can use

\#include <tvm_vendor/dlpack/dlpack.h>

Signed-off-by: Kurtis Charnock <kurtis.charnock@arm.com>
Issue-Id: SCM-1400
Change-Id: I4e9868598bd4cc5e81f11bdc275fdd360adc0799